### PR TITLE
Make the rails version in the gemspec more restrictive

### DIFF
--- a/transam_funding.gemspec
+++ b/transam_funding.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency 'rails', '>=4.1.9'
+  s.add_dependency 'rails', '~> 4.1.9'
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails"


### PR DESCRIPTION
Part of a group of changes, addressing the problem that TransAM Engine dependencies were breaking bundler. Pull them in this order so that travis can confirm the changes work:

* spatial
* audit
* lib
* sign
* accounting
* cpt
* funding
