### PR TITLE
Fix funding requests

### DIFF
--- a/app/models/funding_request.rb
+++ b/app/models/funding_request.rb
@@ -145,17 +145,17 @@ class FundingRequest < ActiveRecord::Base
   end
 
   def update_buckets
-    if self.changes.include? 'federal_funding_line_item_id' && !self.federal_amount_was.nil?
+    if self.changes.include?('federal_funding_line_item_id') && !self.federal_amount_was.nil?
       f = FundingBucket.find_by(id: self.federal_funding_line_item_id_was)
       f.budget_committed -= self.federal_amount_was
       f.save!
     end
-    if self.changes.include? 'state_funding_line_item_id' && !self.state_funding_line_item_id_was.nil?
+    if self.changes.include?('state_funding_line_item_id') && !self.state_funding_line_item_id_was.nil?
       f = FundingBucket.find_by(id: self.state_funding_line_item_id_was)
       f.budget_committed -= self.state_amount_was
       f.save!
     end
-    if self.changes.include? 'local_funding_line_item_id' && !self.local_funding_line_item_id_was.nil?
+    if self.changes.include?('local_funding_line_item_id') && !self.local_funding_line_item_id_was.nil?
       f = FundingBucket.find_by(id: self.local_funding_line_item_id_was)
       f.budget_committed -= self.local_amount_was
       f.save!


### PR DESCRIPTION
The first fix adds some missing parens in the conditional. Before we were checking includes? on the boolean result of the &&.

The second fix moves updating new buckets to a separate callback that occurs after_save. Since we are summing amounts from FundingRequests in the database that reference the new bucket, doing this before_save misses the creating/updating FundingRequest. Which will either not exist in the database or still reference the old bucket.

The second fix does add a risk of something going wrong between the callback steps. If you think it's important to do these operations in the same step, we could instead add the amounts for the updating FundingRequest to a sum we get from the database (excluding the current one in case it's been previously saved).